### PR TITLE
override bulkInsert to use transactions, making the operation way faster

### DIFF
--- a/src/org/mariotaku/twidere/provider/TweetStoreProvider.java
+++ b/src/org/mariotaku/twidere/provider/TweetStoreProvider.java
@@ -69,6 +69,22 @@ public final class TweetStoreProvider extends ContentProvider implements Constan
 	};
 
 	@Override
+	public int bulkInsert(Uri uri, ContentValues[] values) {
+		final String table = getTableNameForContentUri(uri);
+		int result = 0;
+		if (table != null) {
+			database.beginTransaction();
+			for (ContentValues contentValues : values) {
+				database.insert(table, null, contentValues);
+				result++;
+			}
+			database.setTransactionSuccessful();
+			database.endTransaction();
+		}
+		return result;
+	};
+
+	@Override
 	public int delete(Uri uri, String selection, String[] selectionArgs) {
 		final String table = getTableNameForContentUri(uri);
 		int result = 0;


### PR DESCRIPTION
hey.

I found out, that you are using the native "bulkInsert" method of the ContentResolver. This one doesn't use transactions, which makes it painfully slow.

I've overridden the method in TweetStoreProvider, so that it uses transactions. For me it is 10 times faster, now.
I avoided calling "onDatabaseUpdated" as I figured it isn't needed at this point, because the native method wouldn't have called it either.

Thanks for this great client. I hope, my update is useful.

Greetings from Germany,
Matthias (@bestform in twitter)
