### PR TITLE
added option to display an absolute timestamp in tweet

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -295,5 +295,7 @@
 	<string name="default_provider">Default</string>
 	<string name="image_uploader">Image uploader</string>
 	<string name="home_refresh">Refresh in home timeline</string>
+	<string name="show_absolute_time">Show absolute time</string>
+	<string name="show_absolute_time_summary">Show absolute time in tweets</string>
 
 </resources>

--- a/res/xml/settings_appearance.xml
+++ b/res/xml/settings_appearance.xml
@@ -22,5 +22,6 @@
 		android:key="leftside_compose_button"
 		android:summary="@string/leftside_compose_button_summary"
 		android:title="@string/leftside_compose_button"/>
+	<CheckBoxPreference android:key="show_absolute_time" android:summary="@string/show_absolute_time_summary" android:title="@string/show_absolute_time" android:defaultValue="false"/>
 
 </PreferenceScreen>

--- a/src/org/mariotaku/twidere/Constants.java
+++ b/src/org/mariotaku/twidere/Constants.java
@@ -129,6 +129,7 @@ public interface Constants extends TwitterConstants {
 	public static final String PREFERENCE_KEY_DISPLAY_NAME = "display_name";
 	public static final String PREFERENCE_KEY_COMPOSE_BUTTON = "bottom_compose_button";
 	public static final String PREFERENCE_KEY_LEFTSIDE_COMPOSE_BUTTON = "leftside_compose_button";
+	public static final String PREFERENCE_KEY_SHOW_ABSOLUTE_TIME = "show_absolute_time";
 	public static final String PREFERENCE_KEY_ATTACH_LOCATION = "attach_location";
 	public static final String PREFERENCE_KEY_ENABLE_FILTER = "enable_filter";
 	public static final String PREFERENCE_KEY_GZIP_COMPRESSING = "gzip_compressing";

--- a/src/org/mariotaku/twidere/adapter/CursorStatusesAdapter.java
+++ b/src/org/mariotaku/twidere/adapter/CursorStatusesAdapter.java
@@ -33,6 +33,8 @@ import static org.mariotaku.twidere.util.Utils.isNullOrEmpty;
 import static org.mariotaku.twidere.util.Utils.openUserProfile;
 import static org.mariotaku.twidere.util.Utils.parseURL;
 
+import java.text.DateFormat;
+
 import org.mariotaku.twidere.R;
 import org.mariotaku.twidere.model.ImageSpec;
 import org.mariotaku.twidere.model.ParcelableStatus;
@@ -41,6 +43,7 @@ import org.mariotaku.twidere.model.StatusCursorIndices;
 import org.mariotaku.twidere.model.StatusViewHolder;
 import org.mariotaku.twidere.util.LazyImageLoader;
 import org.mariotaku.twidere.util.StatusesAdapterInterface;
+import org.mariotaku.twidere.util.Utils;
 
 import android.app.Activity;
 import android.content.Context;
@@ -117,10 +120,19 @@ public class CursorStatusesAdapter extends SimpleCursorAdapter implements Status
 			holder.text.setText(unescapeHTML(text));
 			holder.name.setCompoundDrawablesWithIntrinsicBounds(getUserTypeIconRes(is_verified, is_protected), 0, 0, 0);
 			holder.name.setText(name);
-			holder.time.setText(DateUtils.getRelativeTimeSpanString(status_timestamp));
+			
+			CharSequence time = null;
+			if(Utils.getShowAbsoluteTime(context)){
+				time = DateUtils.formatSameDayTime(status_timestamp, System.currentTimeMillis(), DateFormat.MEDIUM, DateFormat.SHORT);
+			} else {
+				time = DateUtils.getRelativeTimeSpanString(status_timestamp);
+			}
+
+			holder.time.setText(time);
 			holder.time.setCompoundDrawablesWithIntrinsicBounds(0, 0,
 					getStatusTypeIconRes(is_favorite, has_location, has_media), 0);
 
+			
 			holder.reply_retweet_status.setVisibility(is_retweet || is_reply ? View.VISIBLE : View.GONE);
 			if (is_retweet) {
 				holder.reply_retweet_status.setText(retweet_count > 1 ? mContext.getString(

--- a/src/org/mariotaku/twidere/util/Utils.java
+++ b/src/org/mariotaku/twidere/util/Utils.java
@@ -1116,6 +1116,11 @@ public final class Utils implements Constants {
 		return quote_format.replace(QUOTE_FORMAT_NAME_PATTERN, screen_name).replace(QUOTE_SHARE_FORMAT_TEXT_PATTERN,
 				text);
 	}
+	
+	public static boolean getShowAbsoluteTime(Context context) {
+		if (context == null) return false;
+		return context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE).getBoolean(PREFERENCE_KEY_SHOW_ABSOLUTE_TIME, false);
+	}
 
 	/**
 	 * @deprecated


### PR DESCRIPTION
As I prefer to see, when a tweet was composed (as opposed to the time elapsed) I added the option to display the timestamp as an absolute time.

If it is on the same day, it shows the time, otherwise the date. It might be good to add further options here (like time format (12/24h etc), but I tried to avoid going overboard here. ;)
