### PR TITLE
Renamed TestBroadcastReceiver class to

### DIFF
--- a/src/org/mariotaku/twidere/receiver/SecretCodeBroadcastReceiver.java
+++ b/src/org/mariotaku/twidere/receiver/SecretCodeBroadcastReceiver.java
@@ -25,7 +25,7 @@ import android.content.Intent;
 
 import org.mariotaku.twidere.activity.TestActivity;
 
-public class TestBroadcastReceiver extends BroadcastReceiver {
+public class SecretCodeBroadcastReceiver extends BroadcastReceiver {
 
 	@Override
 	public void onReceive(final Context context, final Intent intent) {


### PR DESCRIPTION
Renaming the class to match the file it is contained in, is necessary to get the app to compile. 
